### PR TITLE
added some Mie features plus outline for code to compute g

### DIFF
--- a/examples/simple.py
+++ b/examples/simple.py
@@ -1,31 +1,30 @@
 import wpspecdev
 from matplotlib import pyplot as plt
 args = {  
-'wavelength_list': [300e-9, 800e-9, 100],  
-'sphere_material': "au",
+'wavelength_list': [300e-9, 800e-9, 500],  
+'sphere_material': "tio2",
 'medium_material': "air",
-'radius': 5e-9  
+'radius': 500e-9  
 }  
 
 sf = wpspecdev.SpectrumFactory()  
 mt_5 = sf.spectrum_factory('Mie', args)
-args['radius'] = 20e-9
+args['radius'] = 600e-9
 mt_20 = sf.spectrum_factory('Mie', args)
-args['radius'] = 40e-9
+args['radius'] = 700e-9
 mt_40 = sf.spectrum_factory('Mie', args)
-args['radius'] = 80e-9
+args['radius'] = 800e-9
 mt_80 = sf.spectrum_factory('Mie', args)
 
 
 
 
-plt.plot(mt_5.wavelength_array*1e9, mt_5.q_abs, label='r=5 nm')
-plt.plot(mt_5.wavelength_array*1e9, mt_20.q_abs, label='r=20 nm')
-plt.plot(mt_5.wavelength_array*1e9, mt_40.q_abs,label='r=40 nm')
+plt.plot(mt_5.wavelength_array*1e9, mt_5.q_scat, label='r=5 nm')
+plt.plot(mt_5.wavelength_array*1e9, mt_20.q_scat, label='r=20 nm')
+plt.plot(mt_5.wavelength_array*1e9, mt_40.q_scat,label='r=40 nm')
 plt.xlabel("Wavelength (nm)")
 plt.ylabel("Absorption efficiency")
 plt.legend()
-plt.savefig("absorption.png")
 plt.show()
 
 

--- a/wpspecdev/mie.py
+++ b/wpspecdev/mie.py
@@ -459,3 +459,26 @@ class MieDriver(SpectrumDriver, Materials):
     def _compute_n_array(self, x):
         _n_max = int(x + 4 * x ** (1 / 3.0) + 2)
         self._n_array = np.copy(np.linspace(1, _n_max, _n_max, dtype=int))
+
+    
+    def _compute_gl(r, h, mu, omega_p):
+        ''' docstring goes here! '''
+
+    def _compute_omega_l(omega_p, eps_inf, eps_d):
+        """ docstring goes here! """
+
+    def compute_hamiltonian(self, h, drude_dictionary, emitter_dictionary):
+        """ docstring goes here! """
+        # get parameters of the metal nanoparticle
+        _omega_p = drude_dictionary['omega_p']
+        _eps_inf = drude_dictionary['eps_inf']
+        _gamma_p = drude_dictionary['gamma_p']
+        _eps_D = drude_dictionary['eps_d']
+
+        # get parameters of the quantum emitter
+        _gamma_qe = emitter_dictionary['gamma_qe']
+        _omega_0 = emitter_dictionary['omega_0']
+        _mu = emitter_dictionary['mu']
+
+    
+


### PR DESCRIPTION
## Description
Adds some basic input parsing for MieDriver class, including interface to the Materials class.  Also added placeholder methods for computing coupling constant between quantum emitter and a metal nanoparticle via Eq. (6) and (7) from this article in PRL: 10.1103/PhysRevLett.112.253601 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Users can now specify radius and material of a sphere for a Mie theory calculation, yielding absorption, extinction, and scattering efficiency by default
  - [ ] placeholder functions for computing coupling between metal sphere and quantum emitter added in methods
         - compute_hamiltonian()
         - _compute_gl()
         - _compute_omega_l() 

## Questions
- [ ] Can we implement these empty functions in ~1 hr on Friday???


