### PR TITLE
First refactoring steps

### DIFF
--- a/wptherml/core/__init__.py
+++ b/wptherml/core/__init__.py
@@ -1,0 +1,23 @@
+"""Core shared types and utilities for wptherml."""
+
+from .types import (
+    AngleResolvedResult,
+    LayerStack,
+    SpectralGrid,
+    SpectrumResult,
+    TmmGradientResult,
+    TmmKernelState,
+    TmmObservablesResult,
+    TmmSimulationRequest,
+)
+
+__all__ = [
+    "AngleResolvedResult",
+    "LayerStack",
+    "SpectralGrid",
+    "SpectrumResult",
+    "TmmGradientResult",
+    "TmmKernelState",
+    "TmmObservablesResult",
+    "TmmSimulationRequest",
+]

--- a/wptherml/core/types.py
+++ b/wptherml/core/types.py
@@ -1,0 +1,172 @@
+"""Core typed containers used across wptherml modules.
+
+This module introduces lightweight dataclasses to represent simulation requests
+and standardized result objects.  The intent is to decouple physics kernels
+from legacy driver classes and support progressive API migration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Optional, Sequence
+
+import numpy as np
+from numpy.typing import NDArray
+
+ArrayF = NDArray[np.float64]
+ArrayC = NDArray[np.complex128]
+
+
+@dataclass(frozen=True)
+class LayerStack:
+    """Layer-stack geometry and material identity.
+
+    Parameters
+    ----------
+    thickness_m : numpy.ndarray
+        One-dimensional array of layer thicknesses in meters with shape
+        ``(number_of_layers,)``.
+    materials : Sequence[str]
+        Material labels for each layer.  The length should match
+        ``thickness_m``.
+    """
+
+    thickness_m: ArrayF
+    materials: Sequence[str]
+
+
+@dataclass(frozen=True)
+class SpectralGrid:
+    """Spectral and angular sampling definition.
+
+    Parameters
+    ----------
+    wavelength_m : numpy.ndarray
+        One-dimensional wavelength grid in meters.
+    incident_angle_rad : float, optional
+        Incident angle in radians used for single-angle calculations.
+    polarization : str, optional
+        Input polarization (typically ``"s"`` or ``"p"``).
+    theta_vals_rad : numpy.ndarray, optional
+        Explicit angle grid for angle-resolved calculations.
+    theta_weights : numpy.ndarray, optional
+        Quadrature weights corresponding to ``theta_vals_rad``.
+    """
+
+    wavelength_m: ArrayF
+    incident_angle_rad: float = 0.0
+    polarization: str = "p"
+    theta_vals_rad: Optional[ArrayF] = None
+    theta_weights: Optional[ArrayF] = None
+
+
+@dataclass(frozen=True)
+class TmmSimulationRequest:
+    """Input definition for a TMM observable calculation.
+
+    Parameters
+    ----------
+    stack : LayerStack
+        Layer-stack specification.
+    grid : SpectralGrid
+        Spectral and angular sampling parameters.
+    refractive_index_nk : numpy.ndarray, optional
+        Precomputed complex refractive-index array with shape
+        ``(number_of_wavelengths, number_of_layers)``.  If omitted, callers are
+        expected to provide material models externally.
+    backend : str, optional
+        Backend selection hint.  Supported values are ``"auto"``, ``"scalar"``,
+        and ``"vectorized"``.
+    compute_gradient : bool, optional
+        Flag indicating whether gradients should be computed.
+    gradient_layers : numpy.ndarray, optional
+        Layers to include in gradient calculations.
+    """
+
+    stack: LayerStack
+    grid: SpectralGrid
+    refractive_index_nk: Optional[ArrayC] = None
+    backend: str = "auto"
+    compute_gradient: bool = False
+    gradient_layers: Optional[ArrayF] = None
+
+
+@dataclass
+class SpectrumResult:
+    """Wavelength-resolved optical observables.
+
+    Parameters
+    ----------
+    reflectivity : numpy.ndarray
+        Reflectivity array versus wavelength.
+    transmissivity : numpy.ndarray
+        Transmissivity array versus wavelength.
+    emissivity : numpy.ndarray
+        Emissivity array versus wavelength.
+    wavelength_m : numpy.ndarray
+        Wavelength grid used for the calculation.
+    """
+
+    reflectivity: ArrayF
+    transmissivity: ArrayF
+    emissivity: ArrayF
+    wavelength_m: ArrayF
+
+
+@dataclass
+class AngleResolvedResult:
+    """Angle- and wavelength-resolved optical observables."""
+
+    reflectivity_s: Optional[ArrayF] = None
+    reflectivity_p: Optional[ArrayF] = None
+    transmissivity_s: Optional[ArrayF] = None
+    transmissivity_p: Optional[ArrayF] = None
+    emissivity_s: Optional[ArrayF] = None
+    emissivity_p: Optional[ArrayF] = None
+    theta_vals_rad: Optional[ArrayF] = None
+    wavelength_m: Optional[ArrayF] = None
+
+
+@dataclass
+class TmmKernelState:
+    """Optional diagnostic arrays from core kernel execution."""
+
+    kz: Optional[ArrayC] = None
+    k0: Optional[ArrayF] = None
+    kx: Optional[ArrayC] = None
+    transfer_matrix: Optional[ArrayC] = None
+
+
+@dataclass
+class TmmGradientResult:
+    """Gradient arrays for spectral observables."""
+
+    d_reflectivity: Optional[ArrayF] = None
+    d_transmissivity: Optional[ArrayF] = None
+    d_emissivity: Optional[ArrayF] = None
+    gradient_layers: Optional[ArrayF] = None
+
+
+@dataclass
+class TmmObservablesResult:
+    """Unified container for TMM outputs.
+
+    Parameters
+    ----------
+    spectrum : SpectrumResult, optional
+        Wavelength-resolved observables.
+    angle_resolved : AngleResolvedResult, optional
+        Angle-resolved observables.
+    gradient : TmmGradientResult, optional
+        Gradient outputs.
+    state : TmmKernelState, optional
+        Kernel diagnostic arrays.
+    metadata : dict, optional
+        Additional metadata for provenance and backend reporting.
+    """
+
+    spectrum: Optional[SpectrumResult] = None
+    angle_resolved: Optional[AngleResolvedResult] = None
+    gradient: Optional[TmmGradientResult] = None
+    state: Optional[TmmKernelState] = None
+    metadata: Dict[str, str] = field(default_factory=dict)

--- a/wptherml/em.py
+++ b/wptherml/em.py
@@ -52,6 +52,15 @@ def _compute_pm(phil):
     #print(_pm)
     return _pm
 
+
+def _compute_pm_batch(phil):
+    """Compute batched P matrices for each wavelength in an intermediate layer."""
+    _pm = np.zeros((phil.shape[0], 2, 2), dtype=np.complex128)
+    _ci = 1j
+    _pm[:, 0, 0] = np.exp(-_ci * phil)
+    _pm[:, 1, 1] = np.exp(_ci * phil)
+    return _pm
+
 #@jit(nopython=True)
 def _compute_pm_analytical_gradient(kzl, phil):
     """compute the derivative of the P matrix with respect to layer thickness
@@ -637,49 +646,27 @@ class TmmDriver(SpectrumDriver, Materials, Therml):
         self._compute_kx()
         self._compute_kz()
 
-        # compute the reflectivity in a loop for now!
-        self.reflectivity_array = np.zeros_like(self.wavelength_array)
-        self.transmissivity_array = np.zeros_like(self.wavelength_array)
-        self.emissivity_array = np.zeros_like(self.wavelength_array)
+        _tm, _, _cos_theta_array = self._compute_tm_batch(
+            self._refractive_index_array, self._k0_array, self._kz_array, self.thickness_array
+        )
 
-        for i in range(0, self.number_of_wavelengths):
-            _k0 = self._k0_array[i]
-            _ri = self._refractive_index_array[i, :]
-            _kz = self._kz_array[i, :]
+        # reflection amplitude
+        _r = _tm[:, 1, 0] / _tm[:, 0, 0]
 
-            # get transfer matrix, theta_array, and co_theta_array for current k0 value
-            _tm, _theta_array, _cos_theta_array = self._compute_tm(
-                _ri, _k0, _kz, self.thickness_array
-            )
-            #print(F"GOING TO PRINT TM FOR WAVELENGTH {self.wavelength_array[i]*1e9} nm")
-            #print(_tm)
+        # transmission amplitude
+        _t = 1 / _tm[:, 0, 0]
 
-            # if self.gradient==True:
-            #    _tmg = self._compute_tm_grad(_ri, _k0, _kz, self.thickness_array)
+        # refraction angle and RI prefactor for computing transmission
+        _factor = (
+            self._refractive_index_array[:, self.number_of_layers - 1]
+            * _cos_theta_array[:, self.number_of_layers - 1]
+            / (self._refractive_index_array[:, 0] * _cos_theta_array[:, 0])
+        )
 
-            # reflection amplitude
-            _r = _tm[1, 0] / _tm[0, 0]
-
-            # transmission amplitude
-            _t = 1 / _tm[0, 0]
-
-            # refraction angle and RI prefractor for computing transmission
-            _factor = (
-                _ri[self.number_of_layers - 1]
-                * _cos_theta_array[self.number_of_layers - 1]
-                / (_ri[0] * _cos_theta_array[0])
-            )
-
-            # reflectivity
-            self.reflectivity_array[i] = np.real(_r * np.conj(_r))
-
-            # transmissivity
-            self.transmissivity_array[i] = np.real(_t * np.conj(_t) * _factor)
-
-            # emissivity
-            self.emissivity_array[i] = (
-                1 - self.reflectivity_array[i] - self.transmissivity_array[i]
-            )
+        # reflectivity, transmissivity, and emissivity
+        self.reflectivity_array = np.real(_r * np.conj(_r))
+        self.transmissivity_array = np.real(_t * np.conj(_t) * _factor)
+        self.emissivity_array = 1 - self.reflectivity_array - self.transmissivity_array
         # self.render_color("ambient color")
 
     def compute_explicit_angle_spectrum(self):
@@ -745,66 +732,44 @@ class TmmDriver(SpectrumDriver, Materials, Therml):
             self._compute_kx()
             self._compute_kz()
 
-            for j in range(0, self.number_of_wavelengths):
-                _k0 = self._k0_array[j]
-                _ri = self._refractive_index_array[j, :]
-                _kz = self._kz_array[j, :]
+            _tm_s, _, _cos_theta_array_s = self._compute_tm_batch(
+                self._refractive_index_array, self._k0_array, self._kz_array, self.thickness_array, "s"
+            )
+            _tm_p, _, _cos_theta_array_p = self._compute_tm_batch(
+                self._refractive_index_array, self._k0_array, self._kz_array, self.thickness_array, "p"
+            )
 
-                # get transfer matrix, theta_array, and co_theta_array for current k0 value and 's' polarization
-                self.polarization = "s"
-                _tm_s, _theta_array_s, _cos_theta_array_s = self._compute_tm(
-                    _ri, _k0, _kz, self.thickness_array
-                )
+            # reflection amplitude
+            _r_s = _tm_s[:, 1, 0] / _tm_s[:, 0, 0]
+            _r_p = _tm_p[:, 1, 0] / _tm_p[:, 0, 0]
 
-                # get transfer matrix, theta_array, and cos_theta_array for current k0 value and 'p' polarization
-                self.polarization = "p"
-                _tm_p, _theta_array_p, _cos_theta_array_p = self._compute_tm(
-                    _ri, _k0, _kz, self.thickness_array
-                )
+            # transmission amplitude
+            _t_s = 1 / _tm_s[:, 0, 0]
+            _t_p = 1 / _tm_p[:, 0, 0]
 
-                # reflection amplitude
-                _r_s = _tm_s[1, 0] / _tm_s[0, 0]
-                _r_p = _tm_p[1, 0] / _tm_p[0, 0]
+            # refraction angle and RI prefactor for computing transmission
+            _factor_s = (
+                self._refractive_index_array[:, self.number_of_layers - 1]
+                * _cos_theta_array_s[:, self.number_of_layers - 1]
+                / (self._refractive_index_array[:, 0] * _cos_theta_array_s[:, 0])
+            )
+            _factor_p = (
+                self._refractive_index_array[:, self.number_of_layers - 1]
+                * _cos_theta_array_p[:, self.number_of_layers - 1]
+                / (self._refractive_index_array[:, 0] * _cos_theta_array_p[:, 0])
+            )
 
-                # transmission amplitude
-                _t_s = 1 / _tm_s[0, 0]
-                _t_p = 1 / _tm_p[0, 0]
+            # reflectivity
+            self.reflectivity_array_s[i, :] = np.real(_r_s * np.conj(_r_s))
+            self.reflectivity_array_p[i, :] = np.real(_r_p * np.conj(_r_p))
 
-                # refraction angle and RI prefractor for computing transmission
-                _factor_s = (
-                    _ri[self.number_of_layers - 1]
-                    * _cos_theta_array_s[self.number_of_layers - 1]
-                    / (_ri[0] * _cos_theta_array_s[0])
-                )
-                _factor_p = (
-                    _ri[self.number_of_layers - 1]
-                    * _cos_theta_array_p[self.number_of_layers - 1]
-                    / (_ri[0] * _cos_theta_array_p[0])
-                )
+            # transmissivity
+            self.transmissivity_array_s[i, :] = np.real(_t_s * np.conj(_t_s) * _factor_s)
+            self.transmissivity_array_p[i, :] = np.real(_t_p * np.conj(_t_p) * _factor_p)
 
-                # reflectivity
-                self.reflectivity_array_s[i, j] = np.real(_r_s * np.conj(_r_s))
-                self.reflectivity_array_p[i, j] = np.real(_r_p * np.conj(_r_p))
-
-                # transmissivity
-                self.transmissivity_array_s[i, j] = np.real(
-                    _t_s * np.conj(_t_s) * _factor_s
-                )
-                self.transmissivity_array_p[i, j] = np.real(
-                    _t_p * np.conj(_t_p) * _factor_p
-                )
-
-                # emissivity
-                self.emissivity_array_s[i, j] = (
-                    1
-                    - self.reflectivity_array_s[i, j]
-                    - self.transmissivity_array_s[i, j]
-                )
-                self.emissivity_array_p[i, j] = (
-                    1
-                    - self.reflectivity_array_p[i, j]
-                    - self.transmissivity_array_p[i, j]
-                )
+            # emissivity
+            self.emissivity_array_s[i, :] = 1 - self.reflectivity_array_s[i, :] - self.transmissivity_array_s[i, :]
+            self.emissivity_array_p[i, :] = 1 - self.reflectivity_array_p[i, :] - self.transmissivity_array_p[i, :]
 
     def compute_spectrum_gradient(self):
         """computes the following attributes:
@@ -1644,6 +1609,74 @@ class TmmDriver(SpectrumDriver, Materials, Therml):
         _tm = zgemm(1.0, _tm, _DM)
         #print(f"Final transfer matrix (_tm) after last layer multiplication:\n{_tm}")
 
+        return _tm, _THETA, _CTHETA
+
+    def _compute_tm_batch(self, _refractive_index, _k0, _kz, _d, polarization=None):
+        """Compute transfer matrices for all wavelengths using batched matrix multiplications."""
+        _nwl = _refractive_index.shape[0]
+        _nl = self.number_of_layers
+
+        _PHIL = _kz * _d[np.newaxis, :]
+        _THETA = np.zeros((_nwl, _nl), dtype=np.complex128)
+        _CTHETA = np.zeros((_nwl, _nl), dtype=np.complex128)
+
+        _THETA[:, 0] = self.incident_angle
+        _CTHETA[:, 0] = np.cos(self.incident_angle)
+        _CTHETA[:, 1:] = _kz[:, 1:] / (_refractive_index[:, 1:] * _k0[:, np.newaxis])
+        _THETA[:, 1:] = np.arccos(_CTHETA[:, 1:])
+
+        pol = self.polarization if polarization is None else polarization
+        _tm = np.zeros((_nwl, 2, 2), dtype=np.complex128)
+        _dm0, _ = _compute_dm(1.0, 1.0, pol)
+        _tm[:] = _dm0
+        if pol == "s":
+            _tm[:, 1, 0] = _refractive_index[:, 0] * _CTHETA[:, 0]
+            _tm[:, 1, 1] = -_refractive_index[:, 0] * _CTHETA[:, 0]
+        else:
+            _tm[:, 0, 0] = _CTHETA[:, 0]
+            _tm[:, 0, 1] = _CTHETA[:, 0]
+            _tm[:, 1, 0] = _refractive_index[:, 0]
+            _tm[:, 1, 1] = -_refractive_index[:, 0]
+
+        for i in range(1, _nl - 1):
+            _dm = np.zeros((_nwl, 2, 2), dtype=np.complex128)
+            _dim = np.zeros((_nwl, 2, 2), dtype=np.complex128)
+
+            if pol == "s":
+                _dm[:, 0, 0] = 1.0
+                _dm[:, 0, 1] = 1.0
+                _dm[:, 1, 0] = _refractive_index[:, i] * _CTHETA[:, i]
+                _dm[:, 1, 1] = -_refractive_index[:, i] * _CTHETA[:, i]
+            else:
+                _dm[:, 0, 0] = _CTHETA[:, i]
+                _dm[:, 0, 1] = _CTHETA[:, i]
+                _dm[:, 1, 0] = _refractive_index[:, i]
+                _dm[:, 1, 1] = -_refractive_index[:, i]
+
+            _det = 1.0 / (_dm[:, 0, 0] * _dm[:, 1, 1] - _dm[:, 0, 1] * _dm[:, 1, 0])
+            _dim[:, 0, 0] = _det * _dm[:, 1, 1]
+            _dim[:, 0, 1] = -_det * _dm[:, 0, 1]
+            _dim[:, 1, 0] = -_det * _dm[:, 1, 0]
+            _dim[:, 1, 1] = _det * _dm[:, 0, 0]
+
+            _pm = _compute_pm_batch(_PHIL[:, i])
+            _tm = np.matmul(_tm, _dm)
+            _tm = np.matmul(_tm, _pm)
+            _tm = np.matmul(_tm, _dim)
+
+        _dm = np.zeros((_nwl, 2, 2), dtype=np.complex128)
+        if pol == "s":
+            _dm[:, 0, 0] = 1.0
+            _dm[:, 0, 1] = 1.0
+            _dm[:, 1, 0] = _refractive_index[:, -1] * _CTHETA[:, -1]
+            _dm[:, 1, 1] = -_refractive_index[:, -1] * _CTHETA[:, -1]
+        else:
+            _dm[:, 0, 0] = _CTHETA[:, -1]
+            _dm[:, 0, 1] = _CTHETA[:, -1]
+            _dm[:, 1, 0] = _refractive_index[:, -1]
+            _dm[:, 1, 1] = -_refractive_index[:, -1]
+
+        _tm = np.matmul(_tm, _dm)
         return _tm, _THETA, _CTHETA
     
     def _compute_rgb(self, colorblindness="False"):

--- a/wptherml/tmm/__init__.py
+++ b/wptherml/tmm/__init__.py
@@ -1,0 +1,6 @@
+"""Transfer-matrix core package."""
+
+from .api import compute_observables
+from .kernels import compute_transfer_matrix
+
+__all__ = ["compute_observables", "compute_transfer_matrix"]

--- a/wptherml/tmm/api.py
+++ b/wptherml/tmm/api.py
@@ -1,0 +1,62 @@
+"""High-level API wrappers around TMM kernel functions."""
+
+from __future__ import annotations
+
+from wptherml.core.types import (
+    TmmKernelState,
+    TmmObservablesResult,
+    TmmSimulationRequest,
+)
+
+from .kernels import compute_k0, compute_kx, compute_kz, compute_transfer_matrix
+from .observables import spectrum_from_transfer_matrix
+
+
+def compute_observables(request: TmmSimulationRequest) -> TmmObservablesResult:
+    """Compute TMM observables from a structured request object.
+
+    Parameters
+    ----------
+    request : TmmSimulationRequest
+        Structured inputs for transfer-matrix evaluation.
+
+    Returns
+    -------
+    TmmObservablesResult
+        Structured output containing spectrum data and optional state metadata.
+
+    Raises
+    ------
+    ValueError
+        If no refractive index data is available in the request.
+    """
+
+    refractive_index = request.refractive_index_nk
+    if refractive_index is None:
+        raise ValueError(
+            "TmmSimulationRequest.refractive_index_nk is required for this API "
+            "path. Populate refractive_index_nk or use a higher-level driver "
+            "that constructs material optical data."
+        )
+
+    wavelength = request.grid.wavelength_m
+    angle = request.grid.incident_angle_rad
+    polarization = request.grid.polarization
+
+    k0 = compute_k0(wavelength)
+    kx = compute_kx(refractive_index[:, 0], k0, angle)
+    kz = compute_kz(refractive_index, k0, kx)
+    tm, cos_theta = compute_transfer_matrix(
+        refractive_index,
+        k0,
+        kz,
+        request.stack.thickness_m,
+        angle,
+        polarization,
+        request.backend,
+    )
+
+    spectrum = spectrum_from_transfer_matrix(tm, refractive_index, cos_theta, wavelength)
+    state = TmmKernelState(kz=kz, k0=k0, kx=kx, transfer_matrix=tm)
+    metadata = {"backend": request.backend, "polarization": polarization}
+    return TmmObservablesResult(spectrum=spectrum, state=state, metadata=metadata)

--- a/wptherml/tmm/kernels.py
+++ b/wptherml/tmm/kernels.py
@@ -1,0 +1,388 @@
+"""Core transfer-matrix kernels for scalar and batched TMM workflows.
+
+The routines in this module are intentionally side-effect free and operate on
+NumPy arrays only.  Driver classes can use these kernels to build higher-level
+APIs while sharing one numerical implementation.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import numpy as np
+from numpy.typing import NDArray
+
+ArrayF = NDArray[np.float64]
+ArrayC = NDArray[np.complex128]
+
+
+def compute_k0(wavelength_m: ArrayF) -> ArrayF:
+    """Compute free-space wavevector magnitudes.
+
+    Parameters
+    ----------
+    wavelength_m : numpy.ndarray
+        One-dimensional wavelength grid in meters.
+
+    Returns
+    -------
+    numpy.ndarray
+        One-dimensional array of free-space wavevector magnitudes in inverse
+        meters with the same shape as ``wavelength_m``.
+    """
+
+    return 2.0 * np.pi / wavelength_m
+
+
+def compute_kx(refractive_index_incident: ArrayC, k0: ArrayF, incident_angle_rad: float) -> ArrayC:
+    """Compute in-plane wavevector components.
+
+    Parameters
+    ----------
+    refractive_index_incident : numpy.ndarray
+        Complex refractive index in the incident medium for each wavelength.
+    k0 : numpy.ndarray
+        Free-space wavevector magnitudes from :func:`compute_k0`.
+    incident_angle_rad : float
+        Incident angle in radians.
+
+    Returns
+    -------
+    numpy.ndarray
+        Complex in-plane wavevector for each wavelength.
+    """
+
+    return refractive_index_incident * np.sin(incident_angle_rad) * k0
+
+
+def compute_kz(refractive_index: ArrayC, k0: ArrayF, kx: ArrayC) -> ArrayC:
+    """Compute normal wavevector components in each layer.
+
+    Parameters
+    ----------
+    refractive_index : numpy.ndarray
+        Complex refractive index array with shape
+        ``(number_of_wavelengths, number_of_layers)``.
+    k0 : numpy.ndarray
+        Free-space wavevector magnitudes.
+    kx : numpy.ndarray
+        In-plane wavevector components for each wavelength.
+
+    Returns
+    -------
+    numpy.ndarray
+        Complex normal wavevector array with shape
+        ``(number_of_wavelengths, number_of_layers)``.
+    """
+
+    return np.sqrt((refractive_index * k0[:, np.newaxis]) ** 2 - kx[:, np.newaxis] ** 2)
+
+
+def compute_dm_scalar(refractive_index: complex, cosine_theta: complex, polarization: str) -> Tuple[ArrayC, ArrayC]:
+    """Compute scalar D and D-inverse matrices for one layer.
+
+    Parameters
+    ----------
+    refractive_index : complex
+        Refractive index of the current layer.
+    cosine_theta : complex
+        Cosine of propagation angle in the current layer.
+    polarization : str
+        Polarization label (``"s"`` or ``"p"``).
+
+    Returns
+    -------
+    tuple of numpy.ndarray
+        Pair ``(D, D_inv)`` where each matrix has shape ``(2, 2)``.
+    """
+
+    dm = np.zeros((2, 2), dtype=np.complex128)
+    dim = np.zeros((2, 2), dtype=np.complex128)
+
+    if polarization == "s":
+        dm[0, 0] = 1.0
+        dm[0, 1] = 1.0
+        dm[1, 0] = refractive_index * cosine_theta
+        dm[1, 1] = -refractive_index * cosine_theta
+    else:
+        dm[0, 0] = cosine_theta
+        dm[0, 1] = cosine_theta
+        dm[1, 0] = refractive_index
+        dm[1, 1] = -refractive_index
+
+    det = 1.0 / (dm[0, 0] * dm[1, 1] - dm[0, 1] * dm[1, 0])
+    dim[0, 0] = det * dm[1, 1]
+    dim[0, 1] = -det * dm[0, 1]
+    dim[1, 0] = -det * dm[1, 0]
+    dim[1, 1] = det * dm[0, 0]
+    return dm, dim
+
+
+def compute_pm_scalar(phi: complex) -> ArrayC:
+    """Compute scalar propagation matrix for one layer.
+
+    Parameters
+    ----------
+    phi : complex
+        Phase accumulation term ``kz * d`` for one layer.
+
+    Returns
+    -------
+    numpy.ndarray
+        Complex propagation matrix with shape ``(2, 2)``.
+    """
+
+    pm = np.eye(2, dtype=np.complex128)
+    pm[0, 0] = np.exp(-1j * phi)
+    pm[1, 1] = np.exp(1j * phi)
+    return pm
+
+
+def compute_pm_batch(phi: ArrayC) -> ArrayC:
+    """Compute batched propagation matrices for one layer across wavelengths.
+
+    Parameters
+    ----------
+    phi : numpy.ndarray
+        Phase accumulation term for one layer at each wavelength with shape
+        ``(number_of_wavelengths,)``.
+
+    Returns
+    -------
+    numpy.ndarray
+        Batched propagation matrices with shape
+        ``(number_of_wavelengths, 2, 2)``.
+    """
+
+    pm = np.zeros((phi.shape[0], 2, 2), dtype=np.complex128)
+    pm[:, 0, 0] = np.exp(-1j * phi)
+    pm[:, 1, 1] = np.exp(1j * phi)
+    return pm
+
+
+def _compute_cos_theta(refractive_index: ArrayC, k0: ArrayF, kz: ArrayC, incident_angle_rad: float) -> ArrayC:
+    """Compute cosine of propagation angle in each layer.
+
+    Parameters
+    ----------
+    refractive_index : numpy.ndarray
+        Complex refractive-index array with shape ``(n_wavelengths, n_layers)``.
+    k0 : numpy.ndarray
+        Free-space wavevector magnitudes.
+    kz : numpy.ndarray
+        Normal wavevector components with shape ``(n_wavelengths, n_layers)``.
+    incident_angle_rad : float
+        Incident angle in radians.
+
+    Returns
+    -------
+    numpy.ndarray
+        Cosine of propagation angles with shape ``(n_wavelengths, n_layers)``.
+    """
+
+    cos_theta = np.zeros_like(refractive_index, dtype=np.complex128)
+    cos_theta[:, 0] = np.cos(incident_angle_rad)
+    cos_theta[:, 1:] = kz[:, 1:] / (refractive_index[:, 1:] * k0[:, np.newaxis])
+    return cos_theta
+
+
+def compute_tm_scalar(
+    refractive_index: ArrayC,
+    k0: float,
+    kz: ArrayC,
+    thickness_m: ArrayF,
+    incident_angle_rad: float,
+    polarization: str,
+) -> Tuple[ArrayC, ArrayC]:
+    """Compute transfer matrix for one wavelength.
+
+    Parameters
+    ----------
+    refractive_index : numpy.ndarray
+        Refractive index values for each layer with shape ``(n_layers,)``.
+    k0 : float
+        Free-space wavevector magnitude for this wavelength.
+    kz : numpy.ndarray
+        Normal wavevector values for each layer with shape ``(n_layers,)``.
+    thickness_m : numpy.ndarray
+        Layer thicknesses in meters with shape ``(n_layers,)``.
+    incident_angle_rad : float
+        Incident angle in radians.
+    polarization : str
+        Polarization label (``"s"`` or ``"p"``).
+
+    Returns
+    -------
+    tuple of numpy.ndarray
+        Pair ``(tm, cos_theta)`` where ``tm`` has shape ``(2, 2)`` and
+        ``cos_theta`` has shape ``(n_layers,)``.
+    """
+
+    n_layers = refractive_index.shape[0]
+    cos_theta = np.zeros(n_layers, dtype=np.complex128)
+    cos_theta[0] = np.cos(incident_angle_rad)
+    cos_theta[1:] = kz[1:] / (refractive_index[1:] * k0)
+    phi = kz * thickness_m
+
+    _, tm = compute_dm_scalar(refractive_index[0], cos_theta[0], polarization)
+    for i in range(1, n_layers - 1):
+        dm, dim = compute_dm_scalar(refractive_index[i], cos_theta[i], polarization)
+        pm = compute_pm_scalar(phi[i])
+        tm = np.matmul(tm, dm)
+        tm = np.matmul(tm, pm)
+        tm = np.matmul(tm, dim)
+
+    dm, _ = compute_dm_scalar(refractive_index[-1], cos_theta[-1], polarization)
+    tm = np.matmul(tm, dm)
+    return tm, cos_theta
+
+
+def compute_tm_batch(
+    refractive_index: ArrayC,
+    k0: ArrayF,
+    kz: ArrayC,
+    thickness_m: ArrayF,
+    incident_angle_rad: float,
+    polarization: str,
+) -> Tuple[ArrayC, ArrayC]:
+    """Compute transfer matrices for all wavelengths in batch form.
+
+    Parameters
+    ----------
+    refractive_index : numpy.ndarray
+        Complex refractive index array with shape
+        ``(number_of_wavelengths, number_of_layers)``.
+    k0 : numpy.ndarray
+        Free-space wavevector magnitudes with shape ``(number_of_wavelengths,)``.
+    kz : numpy.ndarray
+        Complex normal wavevector array with shape
+        ``(number_of_wavelengths, number_of_layers)``.
+    thickness_m : numpy.ndarray
+        Layer thicknesses in meters with shape ``(number_of_layers,)``.
+    incident_angle_rad : float
+        Incident angle in radians.
+    polarization : str
+        Polarization label (``"s"`` or ``"p"``).
+
+    Returns
+    -------
+    tuple of numpy.ndarray
+        Pair ``(tm, cos_theta)`` where ``tm`` has shape
+        ``(number_of_wavelengths, 2, 2)`` and ``cos_theta`` has shape
+        ``(number_of_wavelengths, number_of_layers)``.
+    """
+
+    n_wavelengths, n_layers = refractive_index.shape
+    phi = kz * thickness_m[np.newaxis, :]
+    cos_theta = _compute_cos_theta(refractive_index, k0, kz, incident_angle_rad)
+
+    tm = np.zeros((n_wavelengths, 2, 2), dtype=np.complex128)
+    if polarization == "s":
+        tm[:, 0, 0] = 1.0
+        tm[:, 0, 1] = 1.0
+        tm[:, 1, 0] = refractive_index[:, 0] * cos_theta[:, 0]
+        tm[:, 1, 1] = -refractive_index[:, 0] * cos_theta[:, 0]
+    else:
+        tm[:, 0, 0] = cos_theta[:, 0]
+        tm[:, 0, 1] = cos_theta[:, 0]
+        tm[:, 1, 0] = refractive_index[:, 0]
+        tm[:, 1, 1] = -refractive_index[:, 0]
+
+    for i in range(1, n_layers - 1):
+        dm = np.zeros((n_wavelengths, 2, 2), dtype=np.complex128)
+        dim = np.zeros((n_wavelengths, 2, 2), dtype=np.complex128)
+
+        if polarization == "s":
+            dm[:, 0, 0] = 1.0
+            dm[:, 0, 1] = 1.0
+            dm[:, 1, 0] = refractive_index[:, i] * cos_theta[:, i]
+            dm[:, 1, 1] = -refractive_index[:, i] * cos_theta[:, i]
+        else:
+            dm[:, 0, 0] = cos_theta[:, i]
+            dm[:, 0, 1] = cos_theta[:, i]
+            dm[:, 1, 0] = refractive_index[:, i]
+            dm[:, 1, 1] = -refractive_index[:, i]
+
+        det = 1.0 / (dm[:, 0, 0] * dm[:, 1, 1] - dm[:, 0, 1] * dm[:, 1, 0])
+        dim[:, 0, 0] = det * dm[:, 1, 1]
+        dim[:, 0, 1] = -det * dm[:, 0, 1]
+        dim[:, 1, 0] = -det * dm[:, 1, 0]
+        dim[:, 1, 1] = det * dm[:, 0, 0]
+
+        pm = compute_pm_batch(phi[:, i])
+        tm = np.matmul(tm, dm)
+        tm = np.matmul(tm, pm)
+        tm = np.matmul(tm, dim)
+
+    dm = np.zeros((n_wavelengths, 2, 2), dtype=np.complex128)
+    if polarization == "s":
+        dm[:, 0, 0] = 1.0
+        dm[:, 0, 1] = 1.0
+        dm[:, 1, 0] = refractive_index[:, -1] * cos_theta[:, -1]
+        dm[:, 1, 1] = -refractive_index[:, -1] * cos_theta[:, -1]
+    else:
+        dm[:, 0, 0] = cos_theta[:, -1]
+        dm[:, 0, 1] = cos_theta[:, -1]
+        dm[:, 1, 0] = refractive_index[:, -1]
+        dm[:, 1, 1] = -refractive_index[:, -1]
+
+    tm = np.matmul(tm, dm)
+    return tm, cos_theta
+
+
+def compute_transfer_matrix(
+    refractive_index: ArrayC,
+    k0: ArrayF,
+    kz: ArrayC,
+    thickness_m: ArrayF,
+    incident_angle_rad: float,
+    polarization: str,
+    backend: str = "auto",
+) -> Tuple[ArrayC, ArrayC]:
+    """Dispatch transfer-matrix evaluation to scalar or vectorized backend.
+
+    Parameters
+    ----------
+    refractive_index : numpy.ndarray
+        Complex refractive-index array with shape ``(n_wavelengths, n_layers)``.
+    k0 : numpy.ndarray
+        Free-space wavevector magnitudes with shape ``(n_wavelengths,)``.
+    kz : numpy.ndarray
+        Complex normal wavevector values with shape ``(n_wavelengths, n_layers)``.
+    thickness_m : numpy.ndarray
+        Layer thickness array.
+    incident_angle_rad : float
+        Incident angle in radians.
+    polarization : str
+        Polarization label.
+    backend : str, optional
+        ``"vectorized"`` forces batched execution, ``"scalar"`` forces looping,
+        and ``"auto"`` currently maps to vectorized execution.
+
+    Returns
+    -------
+    tuple of numpy.ndarray
+        Transfer matrix and cosine-angle arrays.
+    """
+
+    if backend not in {"auto", "scalar", "vectorized"}:
+        raise ValueError("backend must be one of {'auto', 'scalar', 'vectorized'}")
+
+    if backend in {"auto", "vectorized"}:
+        return compute_tm_batch(
+            refractive_index, k0, kz, thickness_m, incident_angle_rad, polarization
+        )
+
+    n_wavelengths = refractive_index.shape[0]
+    tm = np.zeros((n_wavelengths, 2, 2), dtype=np.complex128)
+    cos_theta = np.zeros_like(refractive_index, dtype=np.complex128)
+    for i in range(n_wavelengths):
+        tm[i], cos_theta[i] = compute_tm_scalar(
+            refractive_index[i],
+            k0[i],
+            kz[i],
+            thickness_m,
+            incident_angle_rad,
+            polarization,
+        )
+    return tm, cos_theta

--- a/wptherml/tmm/observables.py
+++ b/wptherml/tmm/observables.py
@@ -1,0 +1,49 @@
+"""Observable assembly helpers for transfer-matrix outputs."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+from wptherml.core.types import SpectrumResult
+
+ArrayC = NDArray[np.complex128]
+
+
+def spectrum_from_transfer_matrix(
+    tm: ArrayC,
+    refractive_index: ArrayC,
+    cos_theta: ArrayC,
+    wavelength_m: NDArray[np.float64],
+) -> SpectrumResult:
+    """Build reflectivity/transmissivity/emissivity from transfer matrices.
+
+    Parameters
+    ----------
+    tm : numpy.ndarray
+        Transfer matrix array with shape ``(number_of_wavelengths, 2, 2)``.
+    refractive_index : numpy.ndarray
+        Complex refractive index array with shape
+        ``(number_of_wavelengths, number_of_layers)``.
+    cos_theta : numpy.ndarray
+        Cosine-angle array with shape ``(number_of_wavelengths, number_of_layers)``.
+    wavelength_m : numpy.ndarray
+        Wavelength grid in meters.
+
+    Returns
+    -------
+    SpectrumResult
+        Structured spectral observables.
+    """
+
+    r = tm[:, 1, 0] / tm[:, 0, 0]
+    t = 1.0 / tm[:, 0, 0]
+    factor = (
+        refractive_index[:, -1] * cos_theta[:, -1] /
+        (refractive_index[:, 0] * cos_theta[:, 0])
+    )
+
+    reflectivity = np.real(r * np.conj(r))
+    transmissivity = np.real(t * np.conj(t) * factor)
+    emissivity = 1.0 - reflectivity - transmissivity
+    return SpectrumResult(reflectivity, transmissivity, emissivity, wavelength_m)

--- a/wptherml2/README.md
+++ b/wptherml2/README.md
@@ -1,0 +1,32 @@
+# wptherml2
+
+`wptherml2` is a clean-room transfer-matrix subpackage scaffold for the next phase of `wptherml`.
+
+This first cut intentionally stays small:
+
+- one-angle TMM observables,
+- scalar and vectorized NumPy backends,
+- typed request/result objects,
+- a working thickness-gradient API,
+- focused tests, docs, and a simple benchmark entry point.
+
+The current gradient implementation uses centered finite differences as a correctness-first baseline. The public API is designed so an analytical gradient engine can replace the internals without breaking callers.
+
+## Public API
+
+```python
+from wptherml2 import (
+    LayerStack,
+    SpectralGrid,
+    TmmRequest,
+    compute_gradients,
+    compute_observables,
+)
+```
+
+## Development
+
+```bash
+cd wptherml2
+python -m pytest -q
+```

--- a/wptherml2/benchmarks/bench_tmm.py
+++ b/wptherml2/benchmarks/bench_tmm.py
@@ -1,0 +1,42 @@
+"""Small benchmark harness for wptherml2."""
+
+from __future__ import annotations
+
+import time
+import sys
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from wptherml2 import LayerStack, SpectralGrid, TmmRequest, compute_observables
+
+
+def main() -> None:
+    wavelengths = np.linspace(400e-9, 900e-9, 2000)
+    stack = LayerStack(thickness_m=[0.0, 100e-9, 150e-9, 80e-9, 0.0])
+    grid = SpectralGrid(wavelength_m=wavelengths, incident_angle_rad=0.2, polarization="p")
+    refractive_index = np.column_stack(
+        [
+            np.ones(wavelengths.size, dtype=np.complex128),
+            np.full(wavelengths.size, 2.0 + 0.02j, dtype=np.complex128),
+            np.full(wavelengths.size, 1.45 + 0.0j, dtype=np.complex128),
+            np.full(wavelengths.size, 2.2 + 0.01j, dtype=np.complex128),
+            np.full(wavelengths.size, 1.5 + 0.0j, dtype=np.complex128),
+        ]
+    )
+    request = TmmRequest(stack=stack, grid=grid, refractive_index_nk=refractive_index)
+
+    start = time.perf_counter()
+    result = compute_observables(request)
+    elapsed_s = time.perf_counter() - start
+
+    print(f"backend={result.state.backend} wavelengths={wavelengths.size} elapsed_s={elapsed_s:.6f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/wptherml2/docs/architecture.md
+++ b/wptherml2/docs/architecture.md
@@ -1,0 +1,41 @@
+# wptherml2 Architecture
+
+`wptherml2` is the narrow TMM core for the next-generation package direction.
+
+## Module boundaries
+
+- `src/wptherml2/types.py`
+  Immutable request/result containers and validation.
+- `src/wptherml2/api.py`
+  Stable public entry points.
+- `src/wptherml2/tmm/wavevectors.py`
+  Wavevector and angle helpers.
+- `src/wptherml2/tmm/matrices.py`
+  Interface and propagation matrix assembly.
+- `src/wptherml2/tmm/solve.py`
+  Forward scalar/vectorized TMM solvers.
+- `src/wptherml2/tmm/gradients.py`
+  Thickness-gradient implementation behind a stable API.
+- `src/wptherml2/materials/base.py`
+  Minimal extension hook for future material providers.
+
+## Current scope
+
+- single-angle spectra,
+- `s` and `p` polarization,
+- scalar and vectorized NumPy execution paths,
+- thickness gradients for spectral observables.
+
+## Explicit non-goals for this scaffold
+
+- legacy `wptherml` driver integration,
+- angle integration,
+- optimization drivers,
+- autodiff backends,
+- broad material-library migration.
+
+## Near-term upgrade path
+
+The main internal seam to improve next is `tmm/gradients.py`.
+It currently uses centered finite differences to keep the scaffold runnable and testable.
+That file can be upgraded to analytical thickness derivatives without changing the public API.

--- a/wptherml2/pyproject.toml
+++ b/wptherml2/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "wptherml2"
+version = "0.1.0"
+description = "A clean transfer-matrix core for multilayer optics."
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [
+    { name = "Foley Lab" }
+]
+license = { text = "LGPLv3" }
+dependencies = [
+    "numpy>=1.23"
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0"
+]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/wptherml2/src/wptherml2/__init__.py
+++ b/wptherml2/src/wptherml2/__init__.py
@@ -1,0 +1,15 @@
+"""Public package exports for wptherml2."""
+
+from .api import compute_gradients, compute_observables
+from .types import GradientResult, KernelState, LayerStack, SpectralGrid, SpectrumResult, TmmRequest
+
+__all__ = [
+    "GradientResult",
+    "KernelState",
+    "LayerStack",
+    "SpectralGrid",
+    "SpectrumResult",
+    "TmmRequest",
+    "compute_gradients",
+    "compute_observables",
+]

--- a/wptherml2/src/wptherml2/api.py
+++ b/wptherml2/src/wptherml2/api.py
@@ -1,0 +1,19 @@
+"""Public API for transfer-matrix calculations."""
+
+from __future__ import annotations
+
+from .tmm.gradients import compute_thickness_gradients
+from .tmm.solve import solve_tmm
+from .types import GradientResult, SpectrumResult, TmmRequest
+
+
+def compute_observables(request: TmmRequest) -> SpectrumResult:
+    """Compute spectral observables for a transfer-matrix request."""
+
+    return solve_tmm(request)
+
+
+def compute_gradients(request: TmmRequest) -> GradientResult:
+    """Compute thickness gradients for spectral observables."""
+
+    return compute_thickness_gradients(request)

--- a/wptherml2/src/wptherml2/materials/__init__.py
+++ b/wptherml2/src/wptherml2/materials/__init__.py
@@ -1,0 +1,5 @@
+"""Material abstractions for future extension points."""
+
+from .base import MaterialModel
+
+__all__ = ["MaterialModel"]

--- a/wptherml2/src/wptherml2/materials/base.py
+++ b/wptherml2/src/wptherml2/materials/base.py
@@ -1,0 +1,14 @@
+"""Minimal material-model protocol for future extension."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from ..types import ArrayC, ArrayF
+
+
+class MaterialModel(Protocol):
+    """Protocol for wavelength-dependent refractive-index providers."""
+
+    def refractive_index(self, wavelength_m: ArrayF) -> ArrayC:
+        """Return complex refractive index over a wavelength grid."""

--- a/wptherml2/src/wptherml2/tmm/__init__.py
+++ b/wptherml2/src/wptherml2/tmm/__init__.py
@@ -1,0 +1,1 @@
+"""Core TMM modules for wptherml2."""

--- a/wptherml2/src/wptherml2/tmm/gradients.py
+++ b/wptherml2/src/wptherml2/tmm/gradients.py
@@ -1,0 +1,45 @@
+"""Gradient helpers for wptherml2."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ..types import GradientResult, TmmRequest
+from .solve import solve_tmm
+
+
+def compute_thickness_gradients(request: TmmRequest) -> GradientResult:
+    """Compute spectral thickness gradients using centered finite differences.
+
+    This is a correctness-first baseline for the new package scaffold. The API
+    is intended to remain stable when analytical thickness derivatives replace
+    the internal implementation.
+    """
+
+    layers = np.asarray(request.gradient_layers, dtype=np.int64)
+    n_wavelengths = request.grid.wavelength_m.shape[0]
+    d_reflectivity = np.zeros((layers.shape[0], n_wavelengths), dtype=np.float64)
+    d_transmissivity = np.zeros_like(d_reflectivity)
+    d_absorptivity = np.zeros_like(d_reflectivity)
+
+    for row, layer in enumerate(layers):
+        thickness_plus = request.stack.thickness_m.copy()
+        thickness_minus = request.stack.thickness_m.copy()
+        thickness_plus[layer] += request.gradient_step_m
+        thickness_minus[layer] -= request.gradient_step_m
+
+        result_plus = solve_tmm(request.with_thickness(thickness_plus))
+        result_minus = solve_tmm(request.with_thickness(thickness_minus))
+
+        scale = 2.0 * request.gradient_step_m
+        d_reflectivity[row] = (result_plus.reflectivity - result_minus.reflectivity) / scale
+        d_transmissivity[row] = (result_plus.transmissivity - result_minus.transmissivity) / scale
+        d_absorptivity[row] = (result_plus.absorptivity - result_minus.absorptivity) / scale
+
+    return GradientResult(
+        wavelength_m=request.grid.wavelength_m,
+        gradient_layers=layers,
+        d_reflectivity=d_reflectivity,
+        d_transmissivity=d_transmissivity,
+        d_absorptivity=d_absorptivity,
+    )

--- a/wptherml2/src/wptherml2/tmm/matrices.py
+++ b/wptherml2/src/wptherml2/tmm/matrices.py
@@ -1,0 +1,45 @@
+"""Matrix assembly utilities for scalar and vectorized TMM paths."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ..types import ArrayC
+
+
+def compute_d_matrix(refractive_index: complex, cosine_theta: complex, polarization: str) -> tuple[ArrayC, ArrayC]:
+    """Construct the interface matrix and its inverse for one layer."""
+
+    d_matrix = np.zeros((2, 2), dtype=np.complex128)
+    if polarization == "s":
+        admittance = refractive_index * cosine_theta
+        d_matrix[0, 0] = 1.0
+        d_matrix[0, 1] = 1.0
+        d_matrix[1, 0] = admittance
+        d_matrix[1, 1] = -admittance
+    else:
+        d_matrix[0, 0] = cosine_theta
+        d_matrix[0, 1] = cosine_theta
+        d_matrix[1, 0] = refractive_index
+        d_matrix[1, 1] = -refractive_index
+
+    d_inverse = np.linalg.inv(d_matrix)
+    return d_matrix, d_inverse
+
+
+def compute_propagation_matrix(phi: complex) -> ArrayC:
+    """Construct the propagation matrix for one layer."""
+
+    propagation = np.eye(2, dtype=np.complex128)
+    propagation[0, 0] = np.exp(-1j * phi)
+    propagation[1, 1] = np.exp(1j * phi)
+    return propagation
+
+
+def compute_propagation_matrices(phi: ArrayC) -> ArrayC:
+    """Construct propagation matrices across all wavelengths for one layer."""
+
+    propagation = np.zeros((phi.shape[0], 2, 2), dtype=np.complex128)
+    propagation[:, 0, 0] = np.exp(-1j * phi)
+    propagation[:, 1, 1] = np.exp(1j * phi)
+    return propagation

--- a/wptherml2/src/wptherml2/tmm/observables.py
+++ b/wptherml2/src/wptherml2/tmm/observables.py
@@ -1,0 +1,20 @@
+"""Observable assembly from transfer matrices."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ..types import ArrayC
+
+
+def compute_observables(transfer_matrix: ArrayC, refractive_index_nk: ArrayC, cos_theta: ArrayC) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Compute spectral reflectivity, transmissivity, and absorptivity."""
+
+    reflection = transfer_matrix[:, 1, 0] / transfer_matrix[:, 0, 0]
+    transmission = 1.0 / transfer_matrix[:, 0, 0]
+    factor = refractive_index_nk[:, -1] * cos_theta[:, -1] / (refractive_index_nk[:, 0] * cos_theta[:, 0])
+
+    reflectivity = np.real(reflection * np.conjugate(reflection))
+    transmissivity = np.real(transmission * np.conjugate(transmission) * factor)
+    absorptivity = 1.0 - reflectivity - transmissivity
+    return reflectivity, transmissivity, absorptivity

--- a/wptherml2/src/wptherml2/tmm/solve.py
+++ b/wptherml2/src/wptherml2/tmm/solve.py
@@ -1,0 +1,122 @@
+"""Forward TMM solve routines."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ..types import ArrayC, KernelState, SpectrumResult, TmmRequest
+from .matrices import compute_d_matrix, compute_propagation_matrices, compute_propagation_matrix
+from .observables import compute_observables
+from .wavevectors import compute_cos_theta, compute_k0, compute_kx, compute_kz
+
+
+def _resolve_backend(request: TmmRequest) -> str:
+    if request.backend == "auto":
+        return "vectorized"
+    return request.backend
+
+
+def _solve_scalar(request: TmmRequest, k0: np.ndarray, kz: ArrayC) -> tuple[ArrayC, ArrayC]:
+    n_wavelengths, n_layers = request.refractive_index_nk.shape
+    transfer_matrix = np.zeros((n_wavelengths, 2, 2), dtype=np.complex128)
+    cos_theta = np.zeros((n_wavelengths, n_layers), dtype=np.complex128)
+    thickness_m = request.stack.thickness_m
+
+    for idx in range(n_wavelengths):
+        refractive_index = request.refractive_index_nk[idx]
+        kz_row = kz[idx]
+        cos_theta[idx, 0] = np.cos(request.grid.incident_angle_rad)
+        cos_theta[idx, 1:] = kz_row[1:] / (refractive_index[1:] * k0[idx])
+        phase = kz_row * thickness_m
+
+        _, running = compute_d_matrix(refractive_index[0], cos_theta[idx, 0], request.grid.polarization)
+        for layer in range(1, n_layers - 1):
+            d_matrix, d_inverse = compute_d_matrix(refractive_index[layer], cos_theta[idx, layer], request.grid.polarization)
+            running = running @ d_matrix @ compute_propagation_matrix(phase[layer]) @ d_inverse
+
+        last_matrix, _ = compute_d_matrix(refractive_index[-1], cos_theta[idx, -1], request.grid.polarization)
+        transfer_matrix[idx] = running @ last_matrix
+
+    return transfer_matrix, cos_theta
+
+
+def _solve_vectorized(request: TmmRequest, k0: np.ndarray, kz: ArrayC) -> tuple[ArrayC, ArrayC]:
+    refractive_index_nk = request.refractive_index_nk
+    n_wavelengths, n_layers = refractive_index_nk.shape
+    thickness_m = request.stack.thickness_m
+    cos_theta = compute_cos_theta(refractive_index_nk, k0, kz, request.grid.incident_angle_rad)
+
+    transfer_matrix = np.zeros((n_wavelengths, 2, 2), dtype=np.complex128)
+    for idx in range(n_wavelengths):
+        _, incident_inverse = compute_d_matrix(
+            refractive_index_nk[idx, 0],
+            cos_theta[idx, 0],
+            request.grid.polarization,
+        )
+        transfer_matrix[idx] = incident_inverse
+
+    for layer in range(1, n_layers - 1):
+        d_matrices = np.zeros((n_wavelengths, 2, 2), dtype=np.complex128)
+        d_inverses = np.zeros((n_wavelengths, 2, 2), dtype=np.complex128)
+        for idx in range(n_wavelengths):
+            d_matrix, d_inverse = compute_d_matrix(
+                refractive_index_nk[idx, layer],
+                cos_theta[idx, layer],
+                request.grid.polarization,
+            )
+            d_matrices[idx] = d_matrix
+            d_inverses[idx] = d_inverse
+
+        phase = kz[:, layer] * thickness_m[layer]
+        propagation = compute_propagation_matrices(phase)
+        transfer_matrix = transfer_matrix @ d_matrices
+        transfer_matrix = transfer_matrix @ propagation
+        transfer_matrix = transfer_matrix @ d_inverses
+
+    last_matrices = np.zeros((n_wavelengths, 2, 2), dtype=np.complex128)
+    for idx in range(n_wavelengths):
+        d_matrix, _ = compute_d_matrix(
+            refractive_index_nk[idx, -1],
+            cos_theta[idx, -1],
+            request.grid.polarization,
+        )
+        last_matrices[idx] = d_matrix
+    transfer_matrix = transfer_matrix @ last_matrices
+    return transfer_matrix, cos_theta
+
+
+def solve_tmm(request: TmmRequest) -> SpectrumResult:
+    """Run the forward TMM solver and return spectral observables."""
+
+    backend = _resolve_backend(request)
+    k0 = compute_k0(request.grid.wavelength_m)
+    kx = compute_kx(request.refractive_index_nk[:, 0], k0, request.grid.incident_angle_rad)
+    kz = compute_kz(request.refractive_index_nk, k0, kx)
+
+    if backend == "scalar":
+        transfer_matrix, cos_theta = _solve_scalar(request, k0, kz)
+    elif backend == "vectorized":
+        transfer_matrix, cos_theta = _solve_vectorized(request, k0, kz)
+    else:
+        raise ValueError(f"Unsupported backend: {backend}")
+
+    reflectivity, transmissivity, absorptivity = compute_observables(
+        transfer_matrix,
+        request.refractive_index_nk,
+        cos_theta,
+    )
+    state = KernelState(
+        k0=k0,
+        kx=kx,
+        kz=kz,
+        cos_theta=cos_theta,
+        transfer_matrix=transfer_matrix,
+        backend=backend,
+    )
+    return SpectrumResult(
+        wavelength_m=request.grid.wavelength_m,
+        reflectivity=reflectivity,
+        transmissivity=transmissivity,
+        absorptivity=absorptivity,
+        state=state,
+    )

--- a/wptherml2/src/wptherml2/tmm/wavevectors.py
+++ b/wptherml2/src/wptherml2/tmm/wavevectors.py
@@ -1,0 +1,34 @@
+"""Wavevector helpers for transfer-matrix calculations."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ..types import ArrayC, ArrayF
+
+
+def compute_k0(wavelength_m: ArrayF) -> ArrayF:
+    """Compute free-space wavevector magnitude."""
+
+    return 2.0 * np.pi / wavelength_m
+
+
+def compute_kx(refractive_index_incident: ArrayC, k0: ArrayF, incident_angle_rad: float) -> ArrayC:
+    """Compute the in-plane wavevector component."""
+
+    return refractive_index_incident * np.sin(incident_angle_rad) * k0
+
+
+def compute_kz(refractive_index_nk: ArrayC, k0: ArrayF, kx: ArrayC) -> ArrayC:
+    """Compute the normal wavevector in each layer."""
+
+    return np.sqrt((refractive_index_nk * k0[:, None]) ** 2 - kx[:, None] ** 2)
+
+
+def compute_cos_theta(refractive_index_nk: ArrayC, k0: ArrayF, kz: ArrayC, incident_angle_rad: float) -> ArrayC:
+    """Compute cosine of the propagation angle in each layer."""
+
+    cos_theta = np.zeros_like(refractive_index_nk, dtype=np.complex128)
+    cos_theta[:, 0] = np.cos(incident_angle_rad)
+    cos_theta[:, 1:] = kz[:, 1:] / (refractive_index_nk[:, 1:] * k0[:, None])
+    return cos_theta

--- a/wptherml2/src/wptherml2/types.py
+++ b/wptherml2/src/wptherml2/types.py
@@ -1,0 +1,139 @@
+"""Typed input and output containers for wptherml2."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Sequence
+
+import numpy as np
+from numpy.typing import NDArray
+
+ArrayF = NDArray[np.float64]
+ArrayC = NDArray[np.complex128]
+
+
+def _as_float_array(values: Sequence[float]) -> ArrayF:
+    return np.asarray(values, dtype=np.float64)
+
+
+def _as_complex_matrix(values: Sequence[Sequence[complex]]) -> ArrayC:
+    return np.asarray(values, dtype=np.complex128)
+
+
+@dataclass(frozen=True)
+class LayerStack:
+    """Geometry and optional labels for a multilayer stack."""
+
+    thickness_m: ArrayF
+    materials: Sequence[str] | None = None
+
+    def __post_init__(self) -> None:
+        thickness_m = _as_float_array(self.thickness_m)
+        if thickness_m.ndim != 1:
+            raise ValueError("LayerStack.thickness_m must be one-dimensional.")
+        if thickness_m.shape[0] < 2:
+            raise ValueError("LayerStack must include at least incident and exit media.")
+        object.__setattr__(self, "thickness_m", thickness_m)
+
+        if self.materials is not None and len(self.materials) != thickness_m.shape[0]:
+            raise ValueError("LayerStack.materials must match thickness_m length.")
+
+
+@dataclass(frozen=True)
+class SpectralGrid:
+    """Spectral sampling and single-angle illumination settings."""
+
+    wavelength_m: ArrayF
+    incident_angle_rad: float = 0.0
+    polarization: str = "p"
+
+    def __post_init__(self) -> None:
+        wavelength_m = _as_float_array(self.wavelength_m)
+        if wavelength_m.ndim != 1:
+            raise ValueError("SpectralGrid.wavelength_m must be one-dimensional.")
+        if np.any(wavelength_m <= 0.0):
+            raise ValueError("SpectralGrid.wavelength_m must be strictly positive.")
+        if self.polarization not in {"s", "p"}:
+            raise ValueError("SpectralGrid.polarization must be 's' or 'p'.")
+        object.__setattr__(self, "wavelength_m", wavelength_m)
+
+
+@dataclass(frozen=True)
+class TmmRequest:
+    """Input bundle for one-angle TMM calculations."""
+
+    stack: LayerStack
+    grid: SpectralGrid
+    refractive_index_nk: ArrayC
+    backend: str = "auto"
+    gradient_layers: ArrayF | None = None
+    gradient_step_m: float = 1.0e-12
+
+    def __post_init__(self) -> None:
+        refractive_index_nk = _as_complex_matrix(self.refractive_index_nk)
+        n_wavelengths = self.grid.wavelength_m.shape[0]
+        n_layers = self.stack.thickness_m.shape[0]
+
+        if refractive_index_nk.shape != (n_wavelengths, n_layers):
+            raise ValueError(
+                "TmmRequest.refractive_index_nk must have shape "
+                f"({n_wavelengths}, {n_layers})."
+            )
+        if self.backend not in {"auto", "scalar", "vectorized"}:
+            raise ValueError("TmmRequest.backend must be 'auto', 'scalar', or 'vectorized'.")
+        if self.gradient_step_m <= 0.0:
+            raise ValueError("TmmRequest.gradient_step_m must be positive.")
+
+        object.__setattr__(self, "refractive_index_nk", refractive_index_nk)
+
+        if self.gradient_layers is None:
+            layers = np.arange(1, max(1, n_layers - 1), dtype=np.int64)
+        else:
+            layers = np.asarray(self.gradient_layers, dtype=np.int64)
+
+        if layers.ndim != 1:
+            raise ValueError("TmmRequest.gradient_layers must be one-dimensional.")
+        if layers.size > 0:
+            if np.any(layers <= 0) or np.any(layers >= n_layers - 1):
+                raise ValueError("Gradient layers must refer to interior layers only.")
+
+        object.__setattr__(self, "gradient_layers", layers)
+
+    def with_thickness(self, thickness_m: ArrayF) -> "TmmRequest":
+        """Return a new request with updated stack thickness."""
+
+        return replace(self, stack=replace(self.stack, thickness_m=_as_float_array(thickness_m)))
+
+
+@dataclass(frozen=True)
+class KernelState:
+    """Optional diagnostic outputs from the TMM kernel."""
+
+    k0: ArrayF
+    kx: ArrayC
+    kz: ArrayC
+    cos_theta: ArrayC
+    transfer_matrix: ArrayC
+    backend: str
+
+
+@dataclass(frozen=True)
+class SpectrumResult:
+    """Wavelength-resolved TMM observables."""
+
+    wavelength_m: ArrayF
+    reflectivity: ArrayF
+    transmissivity: ArrayF
+    absorptivity: ArrayF
+    state: KernelState | None = None
+
+
+@dataclass(frozen=True)
+class GradientResult:
+    """Thickness gradients for spectral observables."""
+
+    wavelength_m: ArrayF
+    gradient_layers: ArrayF
+    d_reflectivity: ArrayF
+    d_transmissivity: ArrayF
+    d_absorptivity: ArrayF

--- a/wptherml2/tests/conftest.py
+++ b/wptherml2/tests/conftest.py
@@ -1,0 +1,9 @@
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/wptherml2/tests/test_energy_conservation.py
+++ b/wptherml2/tests/test_energy_conservation.py
@@ -1,0 +1,25 @@
+import numpy as np
+
+from wptherml2 import LayerStack, SpectralGrid, TmmRequest, compute_observables
+
+
+def test_energy_is_conserved_for_lossless_stack():
+    wavelengths = np.linspace(400e-9, 800e-9, 11)
+    stack = LayerStack(thickness_m=[0.0, 110e-9, 160e-9, 0.0], materials=["air", "a", "b", "glass"])
+    grid = SpectralGrid(wavelength_m=wavelengths, incident_angle_rad=0.3, polarization="s")
+    refractive_index = np.column_stack(
+        [
+            np.ones(wavelengths.size, dtype=np.complex128),
+            np.full(wavelengths.size, 2.0 + 0.0j, dtype=np.complex128),
+            np.full(wavelengths.size, 1.4 + 0.0j, dtype=np.complex128),
+            np.full(wavelengths.size, 1.5 + 0.0j, dtype=np.complex128),
+        ]
+    )
+
+    result = compute_observables(TmmRequest(stack=stack, grid=grid, refractive_index_nk=refractive_index))
+
+    np.testing.assert_allclose(
+        result.reflectivity + result.transmissivity + result.absorptivity,
+        1.0,
+        atol=1e-10,
+    )

--- a/wptherml2/tests/test_gradients_fd.py
+++ b/wptherml2/tests/test_gradients_fd.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+from wptherml2 import LayerStack, SpectralGrid, TmmRequest, compute_gradients
+
+
+def test_gradient_shapes_match_requested_layers():
+    wavelengths = np.linspace(450e-9, 650e-9, 5)
+    stack = LayerStack(thickness_m=[0.0, 100e-9, 80e-9, 0.0], materials=["air", "a", "b", "glass"])
+    grid = SpectralGrid(wavelength_m=wavelengths, incident_angle_rad=0.1)
+    refractive_index = np.column_stack(
+        [
+            np.ones(wavelengths.size, dtype=np.complex128),
+            np.full(wavelengths.size, 2.1 + 0.01j, dtype=np.complex128),
+            np.full(wavelengths.size, 1.7 + 0.0j, dtype=np.complex128),
+            np.full(wavelengths.size, 1.5 + 0.0j, dtype=np.complex128),
+        ]
+    )
+
+    result = compute_gradients(
+        TmmRequest(
+            stack=stack,
+            grid=grid,
+            refractive_index_nk=refractive_index,
+            gradient_layers=np.array([1, 2]),
+        )
+    )
+
+    assert result.d_reflectivity.shape == (2, wavelengths.size)
+    assert result.d_transmissivity.shape == (2, wavelengths.size)
+    assert result.d_absorptivity.shape == (2, wavelengths.size)

--- a/wptherml2/tests/test_observables.py
+++ b/wptherml2/tests/test_observables.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+from wptherml2 import LayerStack, SpectralGrid, TmmRequest, compute_observables
+
+
+def test_observables_are_bounded_for_passive_stack():
+    wavelengths = np.linspace(500e-9, 900e-9, 7)
+    stack = LayerStack(thickness_m=[0.0, 90e-9, 0.0], materials=["air", "film", "glass"])
+    grid = SpectralGrid(wavelength_m=wavelengths)
+    refractive_index = np.column_stack(
+        [
+            np.ones(wavelengths.size, dtype=np.complex128),
+            np.full(wavelengths.size, 1.8 + 0.0j, dtype=np.complex128),
+            np.full(wavelengths.size, 1.5 + 0.0j, dtype=np.complex128),
+        ]
+    )
+
+    result = compute_observables(TmmRequest(stack=stack, grid=grid, refractive_index_nk=refractive_index))
+
+    assert np.all(result.reflectivity >= -1e-12)
+    assert np.all(result.transmissivity >= -1e-12)
+    assert np.all(result.absorptivity >= -1e-12)
+    assert np.all(result.reflectivity <= 1.0 + 1e-12)

--- a/wptherml2/tests/test_tmm_scalar.py
+++ b/wptherml2/tests/test_tmm_scalar.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+from wptherml2 import LayerStack, SpectralGrid, TmmRequest, compute_observables
+
+
+def test_uniform_medium_has_zero_reflection():
+    wavelengths = np.linspace(400e-9, 700e-9, 5)
+    stack = LayerStack(thickness_m=[0.0, 200e-9, 0.0], materials=["air", "air", "air"])
+    grid = SpectralGrid(wavelength_m=wavelengths, incident_angle_rad=0.0, polarization="s")
+    refractive_index = np.ones((wavelengths.size, 3), dtype=np.complex128)
+    request = TmmRequest(stack=stack, grid=grid, refractive_index_nk=refractive_index, backend="scalar")
+
+    result = compute_observables(request)
+
+    np.testing.assert_allclose(result.reflectivity, 0.0, atol=1e-12)
+    np.testing.assert_allclose(result.transmissivity, 1.0, atol=1e-12)
+    np.testing.assert_allclose(result.absorptivity, 0.0, atol=1e-12)

--- a/wptherml2/tests/test_tmm_vectorized.py
+++ b/wptherml2/tests/test_tmm_vectorized.py
@@ -1,0 +1,26 @@
+import numpy as np
+
+from wptherml2 import LayerStack, SpectralGrid, TmmRequest, compute_observables
+
+
+def test_scalar_and_vectorized_backends_agree():
+    wavelengths = np.linspace(450e-9, 750e-9, 9)
+    stack = LayerStack(thickness_m=[0.0, 120e-9, 0.0], materials=["air", "film", "glass"])
+    grid = SpectralGrid(wavelength_m=wavelengths, incident_angle_rad=0.2, polarization="p")
+
+    refractive_index = np.column_stack(
+        [
+            np.ones(wavelengths.size, dtype=np.complex128),
+            np.full(wavelengths.size, 2.0 + 0.0j, dtype=np.complex128),
+            np.full(wavelengths.size, 1.5 + 0.0j, dtype=np.complex128),
+        ]
+    )
+
+    scalar = compute_observables(TmmRequest(stack=stack, grid=grid, refractive_index_nk=refractive_index, backend="scalar"))
+    vectorized = compute_observables(
+        TmmRequest(stack=stack, grid=grid, refractive_index_nk=refractive_index, backend="vectorized")
+    )
+
+    np.testing.assert_allclose(vectorized.reflectivity, scalar.reflectivity, rtol=1e-10, atol=1e-10)
+    np.testing.assert_allclose(vectorized.transmissivity, scalar.transmissivity, rtol=1e-10, atol=1e-10)
+    np.testing.assert_allclose(vectorized.absorptivity, scalar.absorptivity, rtol=1e-10, atol=1e-10)

--- a/wptherml2/tests/test_types.py
+++ b/wptherml2/tests/test_types.py
@@ -1,0 +1,21 @@
+import numpy as np
+import pytest
+
+from wptherml2 import LayerStack, SpectralGrid, TmmRequest
+
+
+def test_request_validates_shape():
+    stack = LayerStack(thickness_m=[0.0, 100e-9, 0.0], materials=["air", "film", "glass"])
+    grid = SpectralGrid(wavelength_m=np.array([500e-9, 600e-9]))
+
+    with pytest.raises(ValueError):
+        TmmRequest(stack=stack, grid=grid, refractive_index_nk=np.ones((2, 2), dtype=np.complex128))
+
+
+def test_gradient_layers_default_to_interior_layers():
+    stack = LayerStack(thickness_m=[0.0, 100e-9, 200e-9, 0.0])
+    grid = SpectralGrid(wavelength_m=np.array([500e-9]))
+    refractive_index = np.ones((1, 4), dtype=np.complex128)
+    request = TmmRequest(stack=stack, grid=grid, refractive_index_nk=refractive_index)
+
+    np.testing.assert_array_equal(request.gradient_layers, np.array([1, 2]))


### PR DESCRIPTION
# Summary
## Added a new shared typed-model layer in wptherml/core/types.py with dataclasses for TMM request/response flow (TmmSimulationRequest, TmmObservablesResult, SpectrumResult, etc.) to support structured migration away from ad hoc dict-style APIs.
## Added wptherml/tmm/kernels.py with NumPy-style docstrings throughout and a consolidated scalar/vectorized kernel surface:
- wavevector helpers (compute_k0, compute_kx, compute_kz),
- scalar matrix helpers (compute_dm_scalar, compute_pm_scalar, compute_tm_scalar),
- batched helpers (compute_pm_batch, compute_tm_batch),
- backend dispatcher (compute_transfer_matrix).
## Added wptherml/tmm/observables.py with a focused observable assembler (spectrum_from_transfer_matrix) that computes R/T/ε from transfer matrices and returns a typed result object.
## Added wptherml/tmm/api.py with compute_observables(request) as a minimal high-level entry point that orchestrates kernels and returns structured outputs + metadata/state diagnostics.
## Added package initializers for the new namespaces (wptherml/core/__init__.py, wptherml/tmm/__init__.py) to make these modules importable as first-class package components.
